### PR TITLE
Update key.sh

### DIFF
--- a/key.sh
+++ b/key.sh
@@ -2,7 +2,6 @@
 apt-get update -y
 apt-get install curl -y
 yum clean all
-yum make cache
 yum install curl nss -y
 echo '============================
       SSH Key Installer

--- a/key.sh
+++ b/key.sh
@@ -3,7 +3,7 @@ apt-get update -y
 apt-get install curl -y
 yum clean all
 yum make cache
-yum install curl -y
+yum install curl nss -y
 echo '============================
       SSH Key Installer
 	 V1.0 Alpha


### PR DESCRIPTION
防止因nss版本过旧无法获取GitHub上的公钥，目前已发现clouvider的CentOS 6.6系统模板无法正常添加公寓，更新nss后即可正常添加